### PR TITLE
faucet should always assign some minimum tokens to new account

### DIFF
--- a/src/joyApi.ts
+++ b/src/joyApi.ts
@@ -8,7 +8,8 @@ import BN from "bn.js";
 // Init .env config
 config();
 
-const endowment = process.env.ENDOWMENT || ''
+const MIN_ENDOWMENT = '1'
+const endowment = process.env.ENDOWMENT || MIN_ENDOWMENT
 const ENDOWMENT = new BN(parseInt(endowment))
 
 export class JoyApi {


### PR DESCRIPTION
In-case operator forget to configure endowment, the faucet will send one token to avoid same account being used multiple times.