### PR TITLE
add block number to returned message

### DIFF
--- a/src/joyApi.ts
+++ b/src/joyApi.ts
@@ -1,5 +1,6 @@
 import { WsProvider, ApiPromise } from "@polkadot/api";
 import { types } from "@joystream/types";
+import { Hash } from "@joystream/types/common";
 import { Callback, ISubmittableResult } from '@polkadot/types/types'
 import { Keyring } from "@polkadot/keyring";
 import { config } from "dotenv";
@@ -84,6 +85,11 @@ export class JoyApi {
     const nonce = await this.api.rpc.system.accountNextIndex(address)
     const balance = (await this.api.derive.balances.all(address)).freeBalance
     return nonce.eq(0) && balance.eqn(0)
+  }
+
+  async blockHeightFromHash(blockHash: Hash): Promise<number> {
+    const blockHeader = await this.api.rpc.chain.getHeader(blockHash)
+    return blockHeader.number.toNumber()
   }
 
   async addScreenedMember(account: string, handle: string, avatar: string, about: string, callback: Callback<ISubmittableResult>) {

--- a/src/register.ts
+++ b/src/register.ts
@@ -94,9 +94,22 @@ export async function register(joy: JoyApi, account: string, handle: string, ava
       if(success) {
         let memberId = memberIdFromEvent(result.events)
         log('Created New member id:', memberId?.toNumber(), 'handle:', handle)
-        callback({
-          memberId,
-        }, 200)
+
+        const blockHash = result.status.asInBlock
+        joy.blockHeightFromHash(blockHash)
+          .then((blockNumber) => {
+            callback({
+              memberId,
+              block: blockNumber,
+            }, 200)
+          })
+          .catch((reason) => {
+            log('Failed to get extrinsic block number', reason)
+            callback({
+              memberId,
+              block: null,
+            }, 200)
+          })
       } else {
         let errMessage = 'UnknownError'
         const record = failed as EventRecord


### PR DESCRIPTION
This can be used by Atlas to know that the query node processed the block in which the extrinsic was included