### PR TITLE
send email alerts on failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@polkadot/keyring": "7.3.1",
     "@polkadot/util": "7.3.1",
     "@polkadot/util-crypto": "7.3.1",
+    "@sendgrid/mail": "^7.6.2",
     "@types/locks": "^0.2.1",
     "bn.js": "^5.1.2",
     "body-parser": "^1.19.0",
@@ -29,9 +30,9 @@
     "pm2": "^5.1.2"
   },
   "devDependencies": {
+    "@babel/core": "^7.0.0",
     "@polkadot/ts": "^0.4.4",
     "@types/bn.js": "^4.11.6",
-    "@babel/core": "^7.0.0",
     "@types/cors": "^2.8.6",
     "@types/express": "^4.17.6",
     "@types/inquirer": "^7.3.1",

--- a/src/emailAlert.ts
+++ b/src/emailAlert.ts
@@ -6,27 +6,27 @@ import { error, log } from './debug'
 // When API key is not set console logs a warning: API key does not start with "SG.".
 // Send can still be attempted but we will most likely fail with 401 error response not authorized
 // unless ip address based authentication is configured.
-const apiKey = process.env.SENDGRID_API_KEY
+const SENDGRID_API_KEY = process.env.SENDGRID_API_KEY
 // Validated sender address
-const fromEmail = process.env.ALERT_FROM_EMAIL
+const ALERT_FROM_EMAIL = process.env.ALERT_FROM_EMAIL
 // For multiple emails messages use a comma separated list. It is preferable
 // to use a single address of a distribution list to send alerts to multiple users if possible.
-const toEmail = process.env.ALERT_TO_EMAIL
+const ALERT_TO_EMAIL = process.env.ALERT_TO_EMAIL
 
-sendgrid.setApiKey(apiKey || '')
+sendgrid.setApiKey(SENDGRID_API_KEY || '')
 
 export const sendEmailAlert = (message: string) => {
-    if (!(apiKey && fromEmail && toEmail)) {
+    if (!(SENDGRID_API_KEY && ALERT_FROM_EMAIL && ALERT_TO_EMAIL)) {
         log('Email Alerts not configured, not sending email alert.')
         return
     }
 
-    const emails = toEmail.split(',')
+    const emails = ALERT_TO_EMAIL.split(',')
 
     const messages = emails.map((to) => {
         return {
             to,
-            from: fromEmail,
+            from: ALERT_FROM_EMAIL,
             subject: 'Member Faucet Alert',
             text: message,
             html: `<span>${message}</span>`,

--- a/src/emailAlert.ts
+++ b/src/emailAlert.ts
@@ -1,35 +1,45 @@
-const sendgrid = require('@sendgrid/mail')
-
+import sendgrid from '@sendgrid/mail'
 import { error, log } from './debug'
 
-const api_key = process.env.SENDGRID_API_KEY
-const alert_email = process.env.ALERT_EMAIL
+// Reference https://docs.sendgrid.com/for-developers/sending-email/quickstart-nodejs
+
+// When API key is not set console logs a warning: API key does not start with "SG.".
+// Send can still be attempted but we will most likely fail with 401 error response not authorized
+// unless ip address based authentication is configured.
+const apiKey = process.env.SENDGRID_API_KEY
+// Validated sender address
+const fromEmail = process.env.ALERT_FROM_EMAIL
+// For multiple emails messages use a comma separated list. It is preferable
+// to use a single address of a distribution list to send alerts to multiple users if possible.
+const toEmail = process.env.ALERT_TO_EMAIL
+
+sendgrid.setApiKey(apiKey || '')
 
 export const sendEmailAlert = (message: string) => {
-    if (!api_key || !alert_email) {
+    if (!(apiKey && fromEmail && toEmail)) {
         log('Email Alerts not configured, not sending email alert.')
         return
     }
 
-    sendgrid.setApiKey(api_key)
+    const emails = toEmail.split(',')
 
-    const msg = {
-        to: alert_email,
-        from: 'mokhtar@jsgenesis.com',
-        subject: 'Member Faucet Alert',
-        text: message,
-        html: `<span>${message}</span>`,
-    }
+    const messages = emails.map((to) => {
+        return {
+            to,
+            from: fromEmail,
+            subject: 'Member Faucet Alert',
+            text: message,
+            html: `<span>${message}</span>`,
+        }
+    })
 
-    sendgrid.send(msg)
+    const isMultiple = messages.length > 1
+
+    sendgrid.send(messages, isMultiple)
         .then(() => {
             log('Sent Email Alert!')
         })
         .catch((err: any) => {
             error('Failed Sending Email Alert', err)
         })
-}
-
-export const send_test_alert = () => {
-    return sendEmailAlert('test alert message')
 }

--- a/src/emailAlert.ts
+++ b/src/emailAlert.ts
@@ -1,0 +1,35 @@
+const sendgrid = require('@sendgrid/mail')
+
+import { error, log } from './debug'
+
+const api_key = process.env.SENDGRID_API_KEY
+const alert_email = process.env.ALERT_EMAIL
+
+export const sendEmailAlert = (message: string) => {
+    if (!api_key || !alert_email) {
+        log('Email Alerts not configured, not sending email alert.')
+        return
+    }
+
+    sendgrid.setApiKey(api_key)
+
+    const msg = {
+        to: alert_email,
+        from: 'mokhtar@jsgenesis.com',
+        subject: 'Member Faucet Alert',
+        text: message,
+        html: `<span>${message}</span>`,
+    }
+
+    sendgrid.send(msg)
+        .then(() => {
+            log('Sent Email Alert!')
+        })
+        .catch((err: any) => {
+            error('Failed Sending Email Alert', err)
+        })
+}
+
+export const send_test_alert = () => {
+    return sendEmailAlert('test alert message')
+}

--- a/src/register.ts
+++ b/src/register.ts
@@ -6,7 +6,7 @@ import BN from "bn.js";
 import { Hash, MemberId} from "@joystream/types/common";
 import { getDataFromEvent } from "./utils";
 import { formatBalance } from "@polkadot/util";
-
+import { sendEmailAlert } from "./emailAlert";
 
 const MIN_HANDLE_LENGTH = 1;
 const MAX_HANDLE_LENGTH = 100;
@@ -102,6 +102,7 @@ export async function register(joy: JoyApi, account: string, handle: string, nam
     }
   } catch (err) {
     handleRegisterError(err)
+    sendEmailAlert(`Failed to register new member. ${err}`)
     return
   }
 
@@ -112,6 +113,7 @@ export async function register(joy: JoyApi, account: string, handle: string, nam
   } catch (err) {
     topUpSuccessful = false
     error('Failed to top up balance of account:', account, 'Error:', err)
+    sendEmailAlert(`Failed to top up balance for new account ${account}. ${err}`)
   }
 
   let result: RegisterResult = { memberId, ...registeredAtBlock, topUpSuccessful };

--- a/yarn.lock
+++ b/yarn.lock
@@ -683,6 +683,29 @@
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
   integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
 
+"@sendgrid/client@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@sendgrid/client/-/client-7.6.2.tgz#5d08949120dad679f34260f1b875b4f57a8d688e"
+  integrity sha512-Yw3i3vPBBwfiIi+4i7+1f1rwQoLlLsu3qW16d1UuRp6RgX6H6yHYb2/PfqwNyCC0qzqIWGUKPWwYe5ggcr5Guw==
+  dependencies:
+    "@sendgrid/helpers" "^7.6.2"
+    axios "^0.26.0"
+
+"@sendgrid/helpers@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@sendgrid/helpers/-/helpers-7.6.2.tgz#e4abdd4e259611ed549ae8e0f4a46cd4f587e5d1"
+  integrity sha512-kGW0kM2AOHfXjcvB6Lgwa/nMv8IALu0KyNY9X4HSa3MtLohymuhbG9HgjrOh66+BkbsfA03H3bcT0+sPVJ0GKQ==
+  dependencies:
+    deepmerge "^4.2.2"
+
+"@sendgrid/mail@^7.6.2":
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@sendgrid/mail/-/mail-7.6.2.tgz#118650afbb58be82e3178fa172869d929d937118"
+  integrity sha512-IHHZFvgU95aqb11AevQvAfautj2pb8iW8UCiUJ2ae9pRF37e6EkBmU9NgdFjbQ/8Xhhm+KDVDzn/JLxDN/GiBw==
+  dependencies:
+    "@sendgrid/client" "^7.6.2"
+    "@sendgrid/helpers" "^7.6.2"
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -1041,6 +1064,13 @@ axios@^0.21.0:
   integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
   dependencies:
     follow-redirects "^1.14.0"
+
+axios@^0.26.0:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/axios/-/axios-0.26.1.tgz#1ede41c51fcf51bbbd6fd43669caaa4f0495aaa9"
+  integrity sha512-fPwcX4EvnSHuInCMItEhAGnaSEXRBjtzh9fOtsE6E1G6p7vl7edEeZe11QHf18+6+9gR5PbKV/sGKNaD8YaMeA==
+  dependencies:
+    follow-redirects "^1.14.8"
 
 babel-core@^7.0.0-bridge.0:
   version "7.0.0-bridge.0"
@@ -1486,6 +1516,11 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+deepmerge@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.2.2.tgz#44d2ea3679b8f4d4ffba33f03d865fc1e7bf4955"
+  integrity sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+
 defer-to-connect@^1.0.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/defer-to-connect/-/defer-to-connect-1.1.3.tgz#331ae050c08dcf789f8c83a7b81f0ed94f4ac591"
@@ -1820,6 +1855,11 @@ follow-redirects@^1.14.0:
   version "1.14.7"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.7.tgz#2004c02eb9436eee9a21446a6477debf17e81685"
   integrity sha512-+hbxoLbFMbRKDwohX8GkTataGqO6Jb7jGwpAlwgy2bIz25XtRm7KEzJM76R1WiNT5SwZkX4Y75SwBolkpmE7iQ==
+
+follow-redirects@^1.14.8:
+  version "1.14.9"
+  resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.14.9.tgz#dd4ea157de7bfaf9ea9b3fbd85aa16951f78d8d7"
+  integrity sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==
 
 form-data@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
Email alert is sent on member registration failure and top-up failure.

Configured and tested email alerts with our send-grid api key and ran the test email alert 
![Screen Shot 2022-04-26 at 3 31 16 PM](https://user-images.githubusercontent.com/1621012/165290755-5dc833ae-1e21-4fa9-8120-48c388e5679f.png)
