### PR TITLE
bare byte string for handle parameter

### DIFF
--- a/src/joyApi.ts
+++ b/src/joyApi.ts
@@ -118,7 +118,7 @@ export class JoyApi {
   }
 
   async handleIsAlreadyRegistered(handle: string): Promise<boolean> {
-    const handleHash = blake2AsHex(handle)
+    const handleHash = blake2AsHex(Buffer.from(handle))
     const storageSize = await this.api.query.members.memberIdByHandleHash.size(
       handleHash
     )
@@ -142,7 +142,7 @@ export class JoyApi {
     return this.api.tx.members.giftMembership({
       rootAccount: account,
       controllerAccount: account,
-      handle: handle,
+      handle: '0x' + Buffer.from(handle).toString('hex'),
       metadata: createType(
         'Bytes',
         '0x' +


### PR DESCRIPTION
Perhaps more correct approach to match expectation in query-node mapping ?